### PR TITLE
Enable MoveApps OSM mirror

### DIFF
--- a/app/app.py
+++ b/app/app.py
@@ -9,6 +9,7 @@ import geopandas as gpd
 from geopandas import GeoDataFrame
 import osmnx as ox
 import logging
+import os
 
 
 class App(object):
@@ -28,9 +29,10 @@ class App(object):
     @hook_impl
     def execute(self, data: TrajectoryCollection, config: dict) -> TrajectoryCollection:
         """Your app code goes here"""
-
+        ox.settings.overpass_url = os.getenv('OVERPASS_API', "https://overpass-api.de/api")
         ox.settings.use_cache = False
         ox.settings.log_console = True
+
 
         buffers = get_buffers(data)
         roads = get_roads(buffers)


### PR DESCRIPTION
Added line to enable use of MoveApps OSM mirror with fallback defaulting to OSMNX default endpoint